### PR TITLE
Update boostrap version in package.json

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -18,7 +18,7 @@
     {{#router}}
     "vue-router": "^3.0.1",
     {{/router}}
-    "bootstrap": "^4.0.0-beta.2",
+    "bootstrap": "^4.3.1",
     "bootstrap-vue": "^1.2.0",
     "popper.js": "^1.12.9"
   },

--- a/template/package.json
+++ b/template/package.json
@@ -19,7 +19,7 @@
     "vue-router": "^3.0.1",
     {{/router}}
     "bootstrap": "^4.3.1",
-    "bootstrap-vue": "^1.2.0",
+    "bootstrap-vue": "^2.0.0-rc.16",
     "popper.js": "^1.12.9"
   },
   "devDependencies": {


### PR DESCRIPTION
Update boostrap version to 4.3.1 to work properly with Bootstrap-Vue, as stated in the docs. [https://bootstrap-vue.js.org/docs/](https://bootstrap-vue.js.org/docs/)